### PR TITLE
Remove hstore column, create a fully formed geojson column instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ GET  /layername/Z/X/Y[.mvt|.json] (application/octet-stream) - Return GeoJSON or
 Building
 --------
 
+### PostgreSQL
+
+To generate the GeoJSON feature (see below) requires PostgreSQL 9.5+.
+
 ### Mapnik
 
 Mapnik is a C++ library that renders the tiles. hastile requires a Mapnik version that supports Mapbox vector tiles - 

--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ The file contains settings for the database connection and layer configuration, 
   "db-connection": "host=example.com port=5432 user=tiler password=123abc dbname=notoracle"
   "layers": {
     "layer1": { 
-      "query": "SELECT ST_AsGeoJSON(wkb_geometry), hstore(layer1_table)-'wkb_geometry'::text FROM layer1_table WHERE ST_Intersects(wkb_geometry, !bbox_4326!)",
+      "query": "SELECT geojson FROM layer1_table WHERE ST_Intersects(wkb_geometry, !bbox_4326!)",
       "last-modified": "2017-01-15T23:49:36Z"
     },
     "layer2": {
-      "query": "SELECT ST_AsGeoJSON(wkb_geometry), hstore(layer2_table)-'wkb_geometry'::text FROM layer2_table WHERE ST_Intersects(wkb_geometry, !bbox_4326!)",
+      "query": "SELECT geojson FROM layer2_table WHERE ST_Intersects(wkb_geometry, !bbox_4326!)",
       "last-modified": "2017-01-15T23:49:36Z"
     }
   }
@@ -110,6 +110,20 @@ The file contains settings for the database connection and layer configuration, 
 ```
 
 Where, db-connection is a [Postgres connection string](https://www.postgresql.org/docs/9.4/static/libpq-connect.html#LIBPQ-CONNSTRING).
+
+The layer table has two columns: a single GeoJSON formatted feature as JSON and the geometry.  The geometry is used to perform the spatial query and the geojson is the feature returned.
+
+To construct a table with a GeoJSON feature with all properties containing arbitrary columns from a table, create a materialized view like:
+```javascript
+CREATE MATERIALIZED VIEW layer1_table as SELECT jsonb_build_object(
+    'type',      'Feature',
+    'id',         ogc_fid,
+    'geometry',   ST_AsGeoJSON(wkb_geometry)::jsonb,
+    'properties', to_jsonb(row) - 'ogc_fid' - 'wkb_geometry'
+)::json as geojson, row.wkb_geometry as wkb_geometry FROM (SELECT * FROM source_layer1_table) row;
+```
+
+This will create the two columns required: geojson (a GeoJSON feature in JSON format) and the geometry column.
 
 You can configure other database, mapnik and HTTP port settings too:
 ```javascript
@@ -125,17 +139,17 @@ Hastile will replace `!bbox_4326!` with the SQL for a bounding box for the reque
 
 If you want to combine multiple tables into a single layer you can use UNION and MATERIALIZED VIEWS and then query it directly:
 ```SQL
-create materialized view layers as
-  SELECT ST_AsGeoJSON(wkb_geometry) as geojson, * FROM layer1_table
+CREATE MATERIALIZED VIEW layers AS
+  SELECT geojson FROM layer1_table
   UNION
-  SELECT ST_AsGeoJSON(wkb_geometry) as geojson, * FROM layer2_table
+  SELECT geojson FROM layer2_table
 ```
 
 Changing the configuration to:
 ```javascript
   "layers": {
     "layer": {
-      "query": "SELECT geojson, hstore(layers)-ARRAY['wkb_geometry','geojson'] FROM layers WHERE ST_Intersects(wkb_geometry, !bbox_4326!)",
+      "query": "SELECT geojson FROM layers WHERE ST_Intersects(wkb_geometry, !bbox_4326!)",
       ...
     }  
   }

--- a/src/DB.hs
+++ b/src/DB.hs
@@ -6,12 +6,9 @@
 
 module DB where
 
-import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Reader.Class
 import           Data.ByteString            as BS
-import           Data.Map                   as M
-import           Data.Maybe                 (fromMaybe)
 import           Data.Monoid
 import           Data.Text                  as T
 import           Data.Text.Encoding         as TE
@@ -59,9 +56,7 @@ getLayer l = do
 
 mkStatement :: BS.ByteString -> HQ.Query () [TileFeature]
 mkStatement sql = HQ.statement sql
-    HE.unit (HD.rowsList (TileFeature <$> HD.value HD.json <*> propsValue)) False
-  where
-    propsValue = fmap (fromMaybe "") . M.fromList <$> HD.value (HD.hstore replicateM)
+    HE.unit (HD.rowsList (TileFeature <$> HD.value HD.json)) False
 
 -- Replace any occurrance of the string "!bbox_4326!" in a string with some other string
 escape :: Text -> Text -> Text

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -99,21 +99,13 @@ data ServerState = ServerState { _ssPool           :: P.Pool
                                , _ssStateLayers    :: STM.Map Text Layer
                                }
 
-data TileFeature = TileFeature { _tfGeometry   :: Value
-                               , _tfProperties :: M.Map Text Text
+data TileFeature = TileFeature { _tfFeature :: Value
                                }
 
 mkGeoJSON :: [TileFeature] -> GeoJson
 mkGeoJSON tfs = M.fromList [ ("type", String "FeatureCollection")
-                             , ("features", toJSON . fmap mkFeature $ tfs)
-                             ]
-
-mkFeature :: TileFeature -> Value
-mkFeature tf = toJSON featureMap
-  where featureMap = M.fromList [ ("type", String "Feature")
-                                , ("geometry", _tfGeometry tf)
-                                , ("properties", toJSON . _tfProperties $ tf)
-                                ] :: M.Map Text Value
+                           , ("features", toJSON . fmap _tfFeature $ tfs)
+                           ]
 
 err204 :: ServantErr
 err204 = ServantErr { errHTTPCode = 204

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -99,12 +99,11 @@ data ServerState = ServerState { _ssPool           :: P.Pool
                                , _ssStateLayers    :: STM.Map Text Layer
                                }
 
-data TileFeature = TileFeature { _tfFeature :: Value
-                               }
+newtype TileFeature = TileFeature { unTileFeature :: Value } deriving (Show, Eq)
 
 mkGeoJSON :: [TileFeature] -> GeoJson
 mkGeoJSON tfs = M.fromList [ ("type", String "FeatureCollection")
-                           , ("features", toJSON . fmap _tfFeature $ tfs)
+                           , ("features", toJSON . fmap unTileFeature $ tfs)
                            ]
 
 err204 :: ServantErr


### PR DESCRIPTION
I believe this closes #27.  The problem with hstore is that it's strings and there's no way back from strings.  If we store the data as JSON (JSONB) then we get strings and ints!  Also has the nice side effect of creating an id as well.

Just need to change the materialized views to be geojson feature and geometry.  e.g.
```
CREATE MATERIALIZED VIEW "public"."yyy" as SELECT jsonb_build_object(
    'type',       'Feature',
    'id',         ogc_fid,
    'geometry',   ST_AsGeoJSON(wkb_geometry)::jsonb,
    'properties', to_jsonb(row) - 'ogc_fid' - 'wkb_geometry'
)::json as geojson, row.wkb_geometry as wkb_geometry FROM (SELECT * FROM xxx) row;
```

Queries just drop the property column:
```
SELECT geojson FROM yyy WHERE ST_Intersects(wkb_geometry, !bbox_4326!);
```

Requires Postgresql 9.5+.