### PR TITLE
Remove application/octet-stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ A Haskell tile server that produces GeoJSON or MVT (Mapbox Vector Tiles) from a 
 RESTful API
 -----------
 ```
-GET  /                            (application/json)         - Returns the current configuration.
-POST /layername                   (application/json)         - Add/overwrite the query setting for layername (e.g. {"query": "..."}).
-GET  /layername/Z/X/Y/query       (text/plain)               - Query for a given layername, Zoom, and (X,Y).
-GET  /layername/Z/X/Y[.mvt|.json] (application/octet-stream) - Return GeoJSON or Mapnick Vector Tile for given layername, Zoom, (X,Y).
+GET  /                         (application/json)         - Returns the current configuration.
+POST /layername                (application/json)         - Add/overwrite the query setting for layername (e.g. {"query": "..."}).
+GET  /layername/Z/X/Y/query    (text/plain)               - Query for a given layername, Zoom, and (X,Y).
+GET  /layername/Z/X/Y.mvt      (application/vnd.mapbox-vector-tile) - Return Mapnick Vector Tile for given layername, Zoom, (X,Y).
+GET  /layername/Z/X/Y.json     (application/json) - Return GeoJSON for given layername, Zoom, (X,Y).
 ```
 
 Building

--- a/hastile.cabal
+++ b/hastile.cabal
@@ -27,10 +27,11 @@ library
                      , aeson-pretty
                      , bytestring
                      , containers
-                     , hasql
+                     , hasql                     
                      , hasql-pool
                      , here
                      , http-types
+                     , http-media
                      , list-t
                      , mtl
                      , optparse-generic

--- a/hastile.cabal
+++ b/hastile.cabal
@@ -27,7 +27,7 @@ library
                      , aeson-pretty
                      , bytestring
                      , containers
-                     , hasql                     
+                     , hasql
                      , hasql-pool
                      , here
                      , http-types
@@ -35,7 +35,7 @@ library
                      , list-t
                      , mtl
                      , optparse-generic
-                     , servant  
+                     , servant
                      , servant-server
                      , stm-containers
                      , text

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -112,7 +112,7 @@ getJson :: (MonadIO m, MonadError ServantErr m, MonadReader ServerState m)
 getJson l zxy = do
   layer <- getLayerOrThrow l
   geoJson <- getJson' layer zxy
-  pure $ addHeader (lastModified layer) . toStrict . encode $ geoJson
+  pure $ addHeader (lastModified layer) (toStrict $ encode geoJson)
 
 getJson' :: (MonadIO m, MonadError ServantErr m, MonadReader ServerState m)
          => Layer -> Coordinates -> m GeoJson

--- a/src/Routes.hs
+++ b/src/Routes.hs
@@ -21,7 +21,7 @@ type YI = Capture "y" Integer
 type HastileApi =    Get '[JSON] Config
                 :<|> LayerName :> ReqBody '[JSON] LayerQuery :> Post '[JSON] NoContent
                 :<|> LayerName :> Z :> X :> YI :> "query" :> Get '[PlainText] Text
-                :<|> LayerName :> Z :> X :> Y :> Get '[OctetStream] (Headers '[Header "Last-Modified" String] BS.ByteString)
+                :<|> LayerName :> Z :> X :> Y :> Get '[MapboxVectorTile, AlreadyJSON] (Headers '[Header "Last-Modified" String] BS.ByteString)
 
 api :: Proxy HastileApi
 api = Proxy

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -118,23 +118,24 @@ err204 = ServantErr { errHTTPCode = 204
                     , errHeaders = []
                     }
 
-data MapboxVectorTile deriving Typeable
 data AlreadyJSON deriving Typeable
 
 instance Accept AlreadyJSON where
     contentType _ = "application" M.// "json"
 
-instance Accept MapboxVectorTile where
-    contentType _ = "application" M.// "vnd.mapbox-vector-tile"
-
 instance MimeRender AlreadyJSON Data.ByteString.Lazy.ByteString where
-    mimeRender _ = id
-
-instance MimeRender MapboxVectorTile Data.ByteString.Lazy.ByteString where
     mimeRender _ = id
 
 instance MimeRender AlreadyJSON BS.ByteString where
     mimeRender _ = fromStrict
+
+data MapboxVectorTile deriving Typeable
+
+instance Accept MapboxVectorTile where
+    contentType _ = "application" M.// "vnd.mapbox-vector-tile"
+
+instance MimeRender MapboxVectorTile Data.ByteString.Lazy.ByteString where
+    mimeRender _ = id
 
 instance MimeRender MapboxVectorTile BS.ByteString where
     mimeRender _ = fromStrict

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -22,7 +22,7 @@ import           Data.Text            as T
 import           Data.Time
 import           Data.Typeable
 import           Hasql.Pool           as P
-import qualified Network.HTTP.Media   as M
+import qualified Network.HTTP.Media   as HM
 import           Options.Generic
 import           Servant
 import           STMContainers.Map    as STM
@@ -121,7 +121,7 @@ err204 = ServantErr { errHTTPCode = 204
 data AlreadyJSON deriving Typeable
 
 instance Accept AlreadyJSON where
-    contentType _ = "application" M.// "json"
+    contentType _ = "application" HM.// "json"
 
 instance MimeRender AlreadyJSON Data.ByteString.Lazy.ByteString where
     mimeRender _ = id
@@ -132,7 +132,7 @@ instance MimeRender AlreadyJSON BS.ByteString where
 data MapboxVectorTile deriving Typeable
 
 instance Accept MapboxVectorTile where
-    contentType _ = "application" M.// "vnd.mapbox-vector-tile"
+    contentType _ = "application" HM.// "vnd.mapbox-vector-tile"
 
 instance MimeRender MapboxVectorTile Data.ByteString.Lazy.ByteString where
     mimeRender _ = id


### PR DESCRIPTION
Both work now as expected:
- curl -iH "Accept: application/vnd.mapbox-vector-tile" http://localhost:8080/open_traffic_adl/14/14498/9889.mvt
- curl -iH "Accept: application/json" http://localhost:8080/open_traffic_adl/14/14498/9889.json

The file extensions (as intended - although wrong - URLs should be used for determining content type) ignore the header, this will return mvt:
- curl -iH "Accept: application/json" http://localhost:8080/open_traffic_adl/14/14498/9889.mvt 
