### PR TITLE
Add buffering to tiles

### DIFF
--- a/hastile.cabal
+++ b/hastile.cabal
@@ -32,6 +32,7 @@ library
                      , here
                      , http-types
                      , http-media
+                     , lens
                      , list-t
                      , mtl
                      , optparse-generic

--- a/mapnik-vector-tile-c/mvt_from_geojson.cpp
+++ b/mapnik-vector-tile-c/mvt_from_geojson.cpp
@@ -16,6 +16,7 @@ struct _mvtc_return {
 };
 
 mvtc_return * mvtc_from_geo_json(const int tile_size,
+                                 const int buffer_pixels,
                                  const char * geo_json,
                                  const char * layer_name,
                                  const char * mapnik_input_plugins_path,
@@ -46,7 +47,7 @@ mvtc_return * mvtc_from_geo_json(const int tile_size,
     lyr.set_datasource(mapnik::datasource_cache::instance().create(p));
     map.add_layer(lyr);
 
-    mapnik::vector_tile_impl::merc_tile out_tile(x, y, z, tile_size);
+    mapnik::vector_tile_impl::merc_tile out_tile(x, y, z, tile_size, buffer_pixels);
     mapnik::vector_tile_impl::processor ren(map);
     ren.set_area_threshold(area_threshold);
     ren.set_strictly_simple(strictly_simple);
@@ -76,7 +77,7 @@ const char * mvtc_get_mvt(mvtc_return * rv)
   return rv->mvt.c_str();
 }
 
-const int mvtc_get_mvt_size(mvtc_return * rv)
+int mvtc_get_mvt_size(mvtc_return * rv)
 {
   return rv->mvt_size;
 }

--- a/mapnik-vector-tile-c/mvt_from_geojson.h
+++ b/mapnik-vector-tile-c/mvt_from_geojson.h
@@ -14,6 +14,7 @@ typedef enum {
 typedef struct _mvtc_return mvtc_return;
 
 mvtc_return * mvtc_from_geo_json(const int tile_size,
+                                 const int buffer_pixels,
                                  const char * geo_json,
                                  const char * layer_name,
                                  const char * mapnik_input_plugins_path,
@@ -23,7 +24,7 @@ mvtc_return * mvtc_from_geo_json(const int tile_size,
 
 const char * mvtc_get_mvt(mvtc_return * rv);
 
-const int mvtc_get_mvt_size(mvtc_return * rv);
+int mvtc_get_mvt_size(mvtc_return * rv);
 
 mvtc_return_code mvtc_get_return_code(mvtc_return * rv);
 

--- a/src/DB.hs
+++ b/src/DB.hs
@@ -41,9 +41,11 @@ findFeatures layer zxy = do
 
 mkQuery :: (MonadReader ServerState m) => Layer -> Coordinates -> m Text
 mkQuery layer zxy =
-  do buffer <- asks (^. (ssOriginalConfig . configTileBuffer))
-     let (BBox (Metres llX) (Metres llY) (Metres urX) (Metres urY)) =
-           googleToBBoxM defaultTileSize buffer (_zl zxy) (_xy zxy)
+  do buffer <- asks (^. ssBuffer)
+     let zoom = _zl zxy
+         bboxM = googleToBBoxM defaultTileSize zoom (_xy zxy)
+         (BBox (Metres llX) (Metres llY) (Metres urX) (Metres urY)) =
+           addBufferToBBox defaultTileSize buffer zoom bboxM
          bbox4326 = T.pack $ "ST_Transform(ST_SetSRID(ST_MakeBox2D(\
                              \ST_MakePoint(" ++ show llX ++ ", " ++ show llY ++ "), \
                              \ST_MakePoint(" ++ show urX ++ ", " ++ show urY ++ ")), 3857), 4326)"

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -10,6 +10,7 @@ module Lib
     , ServerState (..)
     ) where
 
+import           Control.Lens               ((^.))
 import           Control.Monad.Error.Class
 import           Control.Monad.IO.Class
 import           Control.Monad.Reader.Class
@@ -94,12 +95,11 @@ getTile l zxy = do
   layer <- getLayerOrThrow l
   geoJson <- getJson' layer zxy
   pp <- asks _ssPluginDir
-  eet <- liftIO $ tileReturn geoJson pp
+  buffer <- asks (^. ssBuffer)
+  eet <- liftIO $ fromGeoJSON defaultTileSize buffer geoJson l pp zxy
   case eet of
     Left e -> throwError $ err500 { errBody = fromStrict $ TE.encodeUtf8 e }
     Right tile -> checkEmpty tile layer
-  where
-    tileReturn geoJson' pp' = fromGeoJSON defaultTileSize geoJson' l pp' zxy
 
 checkEmpty :: (MonadIO m, MonadError ServantErr m, MonadReader ServerState m)
            => BS.ByteString -> Layer -> m (Headers '[Header "Last-Modified" String] BS.ByteString)

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -57,7 +57,7 @@ provisionLayer l query = do
   pure NoContent
 
 returnConfiguration ::(MonadIO m, MonadError ServantErr m, MonadReader ServerState m)
-               => m Types.Config
+               => m Types.InputConfig
 returnConfiguration = do
   cfgFile <- asks _ssConfigFile
   configBs <- liftIO $ LBS.readFile cfgFile

--- a/src/MapboxVectorTile.chs
+++ b/src/MapboxVectorTile.chs
@@ -20,12 +20,14 @@ import           Types
 {# enum mvtc_return_code as MvtcReturnCode {underscoreToCase} deriving (Eq) #}
 
 fromGeoJSON :: Pixels
+            -> Pixels
             -> GeoJson
             -> Text
             -> FilePath
             -> Coordinates
             -> IO (Either Text BS8.ByteString)
 fromGeoJSON (Pixels tileSize)
+            (Pixels buffer)
             geoJSON
             layerName
             inputPluginsPath
@@ -35,6 +37,7 @@ fromGeoJSON (Pixels tileSize)
   withCString inputPluginsPath $ \cInputPluginsPath -> do
     mvtcReturn <- MvtcReturn <$> (newForeignPtr mvtc_free_mvtc_return =<<
       {# call mvtc_from_geo_json #} (fromInteger tileSize)
+                                    (fromInteger buffer)
                                     cGeoJSON
                                     cLayerName
                                     cInputPluginsPath

--- a/src/Routes.hs
+++ b/src/Routes.hs
@@ -18,7 +18,7 @@ type X = Capture "x" Integer
 type Y = Capture "y" Text
 type YI = Capture "y" Integer
 
-type HastileApi =    Get '[JSON] Config
+type HastileApi =    Get '[JSON] InputConfig
                 :<|> LayerName :> ReqBody '[JSON] LayerQuery :> Post '[JSON] NoContent
                 :<|> LayerName :> Z :> X :> YI :> "query" :> Get '[PlainText] Text
                 :<|> LayerName :> Z :> X :> Y :> Get '[MapboxVectorTile, AlreadyJSON] (Headers '[Header "Last-Modified" String] BS.ByteString)

--- a/src/Tile.hs
+++ b/src/Tile.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Tile ( extent
@@ -19,7 +20,7 @@ data LatLon a = Lat Double
               deriving (Show, Eq)
 
 -- SW and NE points given as W,S,E,N
-data BBox a = BBox a a a a deriving (Show, Eq)
+data BBox a = BBox a a a a deriving (Show, Eq, Functor)
 
 earthRadius :: Metres
 earthRadius = Metres 6378137
@@ -33,24 +34,21 @@ earthCircumference = 2 * maxExtent
 extent :: BBox Metres
 extent = BBox (-maxExtent) (-maxExtent) maxExtent maxExtent
 
-googleToBBoxM :: Pixels -> ZoomLevel -> GoogleTileCoords -> BBox Metres
-googleToBBoxM tileSize z g =
-  flipYs . transformBBox (flip (-) maxExtent . mPerPxToM mPerPx) $ googleToBBoxPx tileSize g
+googleToBBoxM :: Pixels -> Pixels -> ZoomLevel -> GoogleTileCoords -> BBox Metres
+googleToBBoxM tileSize buffer z g =
+  flipYs . fmap (flip (-) maxExtent . mPerPxToM mPerPx) $ googleToBBoxPx tileSize buffer g
   where mPerPx = mPerPxAtZoom earthCircumference tileSize z
         flipYs (BBox llX llY urX urY) = BBox llX (-llY) urX (-urY)
 
-transformBBox :: (a -> b) -> BBox a -> BBox b
-transformBBox f (BBox llX llY urX urY) = BBox (f llX) (f llY) (f urX) (f urY)
-
-googleToBBoxPx :: Pixels ->  GoogleTileCoords -> BBox Pixels
-googleToBBoxPx tileSize (GoogleTileCoords gx gy) =
-  transformBBox ((* tileSize) . fromIntegral) $ BBox gx (gy + 1) (gx + 1) gy
+googleToBBoxPx :: Pixels -> Pixels -> GoogleTileCoords -> BBox Pixels
+googleToBBoxPx tileSize buffer (GoogleTileCoords gx gy) =
+  fmap ((+ buffer) . (* tileSize) . fromIntegral) $ BBox gx (gy + 1) (gx + 1) gy
 
 pixelMaxExtent :: Pixels -> ZoomLevel -> Pixels
 pixelMaxExtent tile (ZoomLevel z) = (2 ^ z) * tile
 
 -- At each zoom level we double the number of tiles in both the x and y direction.
--- z = 0: 1 tile, z = 1: 2 * 2 = 4 tiles, z = 3: 8 * 8 = 64 tiles
+-- z = 0: 1 tile, z = 1: 2 * 2 = 4 tiles, z = 3: 4 * 4 = 16 tiles
 mPerPxAtZoom :: Metres -> Pixels -> ZoomLevel -> Ratio Metres Pixels
 mPerPxAtZoom (Metres m) tile z = Ratio $ m / fromIntegral p
   where (Pixels p) = pixelMaxExtent tile z

--- a/src/Tile.hs
+++ b/src/Tile.hs
@@ -35,7 +35,6 @@ earthCircumference = 2 * maxExtent
 extent :: BBox Metres
 extent = BBox (-maxExtent) (-maxExtent) maxExtent maxExtent
 
--- | Add buffer to bound box.
 addBufferToBBox :: Pixels -> Pixels -> ZoomLevel -> BBox Metres -> BBox Metres
 addBufferToBBox tileSize buffer z (BBox llX llY urX urY) =
   hardLimit $ BBox (llX - bufferM) (llY - bufferM) (urX + bufferM) (urY + bufferM)
@@ -50,8 +49,9 @@ addBufferToBBox tileSize buffer z (BBox llX llY urX urY) =
 
 googleToBBoxM :: Pixels -> ZoomLevel -> GoogleTileCoords -> BBox Metres
 googleToBBoxM tileSize z g =
-  flipYs . fmap (flip (-) maxExtent . mPerPxToM mPerPx) $ googleToBBoxPx tileSize g
-  where mPerPx = mPerPxAtZoom earthCircumference tileSize z
+  flipYs . fmap googleTo3857 $ googleToBBoxPx tileSize g
+  where googleTo3857 coord = mPerPxToM mPerPx coord - maxExtent
+        mPerPx = mPerPxAtZoom earthCircumference tileSize z
         flipYs (BBox llX llY urX urY) = BBox llX (-llY) urX (-urY)
 
 googleToBBoxPx :: Pixels -> GoogleTileCoords -> BBox Pixels

--- a/src/Tile.hs
+++ b/src/Tile.hs
@@ -12,7 +12,6 @@ import           Types
 
 newtype TileCoord  = TileCoord Integer deriving (Show, Eq, Num)
 newtype Metres = Metres Double deriving (Show, Eq, Num, Floating, Fractional)
-newtype Pixels = Pixels Integer deriving (Show, Eq, Num)
 newtype Ratio n d = Ratio Double deriving (Show, Eq, Num, Floating, Fractional)
 
 data LatLon a = Lat Double

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -14,7 +14,7 @@
 module Types where
 
 import           Control.Applicative
-import           Control.Lens         (makeLenses)
+import           Control.Lens         (Lens', makeLenses)
 import           Data.Aeson
 import qualified Data.ByteString      as BS
 import           Data.ByteString.Lazy (ByteString, fromStrict)
@@ -136,6 +136,9 @@ data ServerState = ServerState { _ssPool           :: P.Pool
                                , _ssStateLayers    :: STM.Map Text Layer
                                }
 makeLenses ''ServerState
+
+ssBuffer :: Lens' ServerState Pixels
+ssBuffer = ssOriginalConfig . configTileBuffer
 
 newtype TileFeature = TileFeature { unTileFeature :: Value } deriving (Show, Eq)
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -7,17 +7,19 @@
 {-# LANGUAGE NoMonomorphismRestriction  #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
 
 module Types where
 
 import           Control.Applicative
+import           Control.Lens         (makeLenses)
 import           Data.Aeson
 import qualified Data.ByteString      as BS
 import           Data.ByteString.Lazy (ByteString, fromStrict)
 import           Data.Map             as M
-import           Data.Maybe
+import           Data.Maybe           (catMaybes)
 import           Data.Text            as T
 import           Data.Time
 import           Data.Typeable
@@ -66,34 +68,59 @@ instance FromJSON Layer where
        Layer <$> o .: "query" <*> o .: "last-modified"
   parseJSON _ = Control.Applicative.empty
 
-data Config = Config { _configPgConnection       :: Text
-                     , _configPgPoolSize         :: Maybe Int
-                     , _configPgTimeout          :: Maybe NominalDiffTime
-                     , _configMapnikInputPlugins :: Maybe FilePath
-                     , _configPort               :: Maybe Int
-                     , _configLayers             :: M.Map Text Layer
-                     , _configTileBuffer         :: Maybe Pixels
+data InputConfig = InputConfig { _inputConfigPgConnection :: Text
+                     , _inputConfigPgPoolSize             :: Maybe Int
+                     , _inputConfigPgTimeout              :: Maybe NominalDiffTime
+                     , _inputConfigMapnikInputPlugins     :: Maybe FilePath
+                     , _inputConfigPort                   :: Maybe Int
+                     , _inputConfigLayers                 :: M.Map Text Layer
+                     , _inputConfigTileBuffer             :: Maybe Pixels
                      } deriving (Show, Generic)
 
-emptyConfig :: Config
-emptyConfig = Config "" Nothing Nothing Nothing Nothing (fromList []) Nothing
+makeLenses ''InputConfig
 
-instance FromJSON Config where
+data Config = Config { _configPgConnection       :: Text
+                     , _configPgPoolSize         :: Int
+                     , _configPgTimeout          :: NominalDiffTime
+                     , _configMapnikInputPlugins :: FilePath
+                     , _configPort               :: Int
+                     , _configLayers             :: M.Map Text Layer
+                     , _configTileBuffer         :: Pixels
+                     } deriving (Show, Generic)
+
+makeLenses ''Config
+
+emptyInputConfig :: InputConfig
+emptyInputConfig = InputConfig "" Nothing Nothing Nothing Nothing (fromList []) Nothing
+
+instance FromJSON InputConfig where
   parseJSON (Object o) =
-       Config <$> o .: "db-connection" <*> o .:? "db-pool-size" <*> o .:? "db-timeout" <*>
+       InputConfig <$> o .: "db-connection" <*> o .:? "db-pool-size" <*> o .:? "db-timeout" <*>
           o .:? "mapnik-input-plugins" <*> o .:? "port" <*> o .: "layers" <*> (fmap . fmap) Pixels (o .:? "tile-buffer")
   parseJSON _ = Control.Applicative.empty
 
 instance ToJSON Config where
-  toJSON c = object $ catMaybes
+  toJSON c = object
     [
-      ("db-connection" .=) <$> Just (_configPgConnection c),
-      ("db-pool-size" .=) <$> _configPgPoolSize c,
-      ("db-timeout" .=) <$> _configPgTimeout c,
-      ("mapnik-input-plugins" .=) <$> _configMapnikInputPlugins c,
-      ("port" .=) <$> _configPort c,
-      ("layers" .=) <$> Just (_configLayers c),
-      ("tile-buffer" .=) <$> Just (_configTileBuffer c)
+      ("db-connection" .= _configPgConnection c),
+      ("db-pool-size" .= _configPgPoolSize c),
+      ("db-timeout" .= _configPgTimeout c),
+      ("mapnik-input-plugins" .= _configMapnikInputPlugins c),
+      ("port" .= _configPort c),
+      ("layers" .= _configLayers c),
+      ("tile-buffer" .= _configTileBuffer c)
+    ]
+
+instance ToJSON InputConfig where
+  toJSON ic = object $ catMaybes
+    [
+      ("db-connection" .=) <$> Just (_inputConfigPgConnection ic),
+      ("db-pool-size" .=) <$> _inputConfigPgPoolSize ic,
+      ("db-timeout" .=) <$> _inputConfigPgTimeout ic,
+      ("mapnik-input-plugins" .=) <$> _inputConfigMapnikInputPlugins ic,
+      ("port" .=) <$> _inputConfigPort ic,
+      ("layers" .=) <$> Just (_inputConfigLayers ic),
+      ("tile-buffer" .=) <$> Just (_inputConfigTileBuffer ic)
     ]
 
 instance ToJSON Layer where
@@ -102,13 +129,13 @@ instance ToJSON Layer where
        "last-modified" .= _layerLastModified l
     ]
 
--- TODO: make lenses!
 data ServerState = ServerState { _ssPool           :: P.Pool
                                , _ssPluginDir      :: FilePath
                                , _ssConfigFile     :: FilePath
                                , _ssOriginalConfig :: Config
                                , _ssStateLayers    :: STM.Map Text Layer
                                }
+makeLenses ''ServerState
 
 newtype TileFeature = TileFeature { unTileFeature :: Value } deriving (Show, Eq)
 

--- a/test/TileSpec.hs
+++ b/test/TileSpec.hs
@@ -35,6 +35,7 @@ testGoogleToBBoxM =
     it "Returns the 3857 extent for zoom level 0" $
       googleToBBoxM 256 0 (GoogleTileCoords 0 0) `shouldBe` extent
 
+-- TODO: Let's stop writing crappy tests and write properties
 testBufferedBoundingBox :: Spec
 testBufferedBoundingBox =
   describe "addBufferToBBox" $ do

--- a/test/TileSpec.hs
+++ b/test/TileSpec.hs
@@ -20,19 +20,32 @@ import           Test.Hspec                      (Spec, describe, it, shouldBe)
 
 import           DB                              (defaultTileSize)
 import           MapboxVectorTile                (fromGeoJSON)
-import           Tile                            (extent, googleToBBoxM)
+import           Tile                            (BBox (..), addBufferToBBox, extent, googleToBBoxM)
 import           Types
 
 spec :: Spec
 spec = do
   testGoogleToBBoxM
+  testBufferedBoundingBox
   testReadMvtFile
 
 testGoogleToBBoxM :: Spec
 testGoogleToBBoxM =
-  describe "Can get a bounding box in 3857 metres from a google tile" $
+  describe "googleToBBoxM" $
     it "Returns the 3857 extent for zoom level 0" $
       googleToBBoxM 256 0 (GoogleTileCoords 0 0) `shouldBe` extent
+
+testBufferedBoundingBox :: Spec
+testBufferedBoundingBox =
+  describe "addBufferToBBox" $ do
+    it "Hard limits to 3857 extent" $
+      let bbox = googleToBBoxM 256 0 (GoogleTileCoords 0 0)
+          buffered = addBufferToBBox 256 128 0 bbox
+       in buffered `shouldBe` extent
+    it "Adding a buffer does what it should" $
+      let bbox@(BBox llX llY urX urY) = googleToBBoxM 256 2 (GoogleTileCoords 1 1)
+          (BBox llX' llY' urX' urY') = addBufferToBBox 256 128 2 bbox
+       in all id [llX' < llX , llY' < llY , urX' > urX , urY' > urY] `shouldBe` True
 
 testReadMvtFile :: Spec
 testReadMvtFile =
@@ -72,5 +85,5 @@ generateMvtFile geoJsonFile layerName coords = do
       decodeError = error . (("Unable to decode " <> geoJsonFile <> ": ") <>)
       geoJson = either decodeError id ebs
   pluginDir <- fromMaybe "/usr/local/lib/mapnik/input" <$> lookupEnv "MAPNIK_PLUGINS_DIR"
-  et <- MapboxVectorTile.fromGeoJSON defaultTileSize geoJson layerName pluginDir coords
+  et <- MapboxVectorTile.fromGeoJSON defaultTileSize 128 geoJson layerName pluginDir coords
   either (error . unpack . ("Failed to create tile: " <>)) (pure . LBS.fromStrict) et


### PR DESCRIPTION
Features near tile boundaries can get clipped when their rendering spills across the boundary. To fix this, we buffer the features queried, and explicitly (was implicit with a default before) buffer the MVT tile produced. As a result, features at the borders get rendered on _both_ tiles, so the full rendering is displayed - renderings on both tiles should join up at the boundary.