### PR TITLE
Ljnicol/windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ dist
 dist-*
 site
 stack.yaml.lock
+._.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-*
 site
 stack.yaml.lock
 ._.DS_Store
+
+release/

--- a/stack.yaml
+++ b/stack.yaml
@@ -53,6 +53,10 @@ extra-deps:
 - wai-middleware-prometheus-1.0.0
 - katip-0.8.0.0
 - Win32-2.5.4.1
+- directory-1.3.4.0
+- process-1.6.7.0
+- time-1.8.0.4
+- text-printer-0.5.0.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
This adds to extra-deps in stack.yaml a few constraints in order to get a successful windows build.

There might be another way of doing this that is platform specific - @newmana do you know if there's a stack.yaml or cabal file way of doing this? (I know we've already got a section for separating windows and unix dependencies).