### PR TITLE
Fix hastile starter layer security

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -82,15 +82,6 @@ setupLayersConfiguration maybeCfgFile dbConnection host port =
           pure (configFileName, config)
         Right newConfig -> pure (configFileName, newConfig)
 
-writeConfigFromDatabaseTables :: FilePath -> Text.Text -> Text.Text -> Int -> Except.ExceptT Text.Text IO Config.Config
-writeConfigFromDatabaseTables cfgFile dbConnection host port = do
-  let config = createConfig dbConnection host port
-  textLayers <- MonadIO.liftIO (Table.getTables config) >>= Except.liftEither
-  boxes <- MonadIO.liftIO (Table.getBboxes config textLayers) >>= Except.liftEither
-  let listLayers = zipWith (\b t -> (t, Layer.defaultLayerSettings { Layer._layerBounds = b } )) boxes textLayers
-  Config.writeLayers listLayers config cfgFile
-  MonadIO.liftIO $ Config.getConfig cfgFile
-
 createConfig :: Text.Text -> Text.Text -> Int -> Config.Config
 createConfig dbConnection host port = Config.addDefaults inputConfig
   where

--- a/src/Hastile/DB/Table.hs
+++ b/src/Hastile/DB/Table.hs
@@ -35,6 +35,7 @@ import qualified Hastile.DB                    as DB
 import qualified Hastile.Lib.Log               as LibLog
 import qualified Hastile.Types.Config          as Config
 import qualified Hastile.Types.Layer           as Layer
+import qualified Hastile.Types.Layer.Security  as LayerSecurity
 
 type RunCheckConfig = Katip.LogEnv -> FilePath -> Config.Config -> IO ()
 
@@ -58,7 +59,7 @@ writeConfigFromDatabaseTables :: FilePath -> Config.Config -> Except.ExceptT Tex
 writeConfigFromDatabaseTables cfgFile config = do
   textLayers <- MonadIO.liftIO (getTables config) >>= Except.liftEither
   boxes <- MonadIO.liftIO (getBboxes config textLayers) >>= Except.liftEither
-  let listLayers = zipWith (\b t -> (t, Layer.defaultLayerSettings { Layer._layerBounds = b } )) boxes textLayers
+  let listLayers = zipWith (\b t -> (t, Layer.defaultLayerSettings { Layer._layerBounds = b, Layer._layerSecurity = Just LayerSecurity.Public } )) boxes textLayers
   Config.writeLayers listLayers config cfgFile
   MonadIO.liftIO $ Config.getConfig cfgFile
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -57,6 +57,7 @@ extra-deps:
 - process-1.6.7.0
 - time-1.8.0.4
 - text-printer-0.5.0.1
+- unix-2.7.2.2
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
When running hastile starter, it generates a config based on database configuration.
The layers generated with this config default to security = private, but the hastile starter just uses the public hastile API.
This PR fixes the starter -> server round trip problem where user assumes behaviour with server --configFile blah should be the same as the starter that generated the config file.

This potentially creates a problem though - if someone deploys a starter config without changing the layer security to private, they are potentially exposing sensitive data. Given running hastile in production is a more advanced workflow, I think it is reasonable to expect users to be aware of this (though we need to document it).
