### PR TITLE
Remove vectortiles dependency

### DIFF
--- a/hastile.cabal
+++ b/hastile.cabal
@@ -71,8 +71,7 @@ library
                      , time
                      , transformers
                      , trifecta
-                     , vector
-                     , vectortiles                 >= 1.5.0                
+                     , vector            
                      , wai
                      , wai-extra
                      , wai-middleware-prometheus
@@ -152,8 +151,7 @@ test-suite hastile-test
                      , temporary
                      , text
                      , time
-                     , unordered-containers
-                     , vectortiles >=1.5.0                
+                     , unordered-containers            
                      , zellige
   ghc-options:       -threaded -rtsopts -with-rtsopts=-N -Wall -Werror -O2
   other-modules:       Hastile.Lib.LayerSpec

--- a/stack.yaml
+++ b/stack.yaml
@@ -38,7 +38,6 @@ resolver: lts-12.26
 packages:
 - '.'
 - '../zellige'
-- '../vectortiles'
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)


### PR DESCRIPTION
Now Zellige is stand-alone, we can remove this dependency.